### PR TITLE
Grow minibuffer

### DIFF
--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -43,6 +43,11 @@ It is then restored when icomplete-vertical-mode is turned off.")
 Records the value when `icomplete-vertical-mode' is turned on.
 It is then restored when icomplete-vertical-mode is turned off.")
 
+(defvar icomplete-vertical-old-resize-mini-windows nil
+  "Store last known value of `resize-mini-windows'.
+Records the value when `icomplete-vertical-mode' is turned on.
+It is then restored when icomplete-vertical-mode is turned off.")
+
 (defun icomplete-vertical-format-completions (completions)
   "Reformat COMPLETIONS for better aesthetics.
 To be used as filter return advice for `icomplete-completions'."
@@ -70,7 +75,9 @@ Meant to be added to `icomplete-minibuffer-setup-hook'."
         (setq icomplete-vertical-old-separator icomplete-separator
               icomplete-separator "\n"
               icomplete-vertical-old-hide-common icomplete-hide-common-prefix
-              icomplete-hide-common-prefix nil)
+              icomplete-hide-common-prefix nil
+              icomplete-vertical-old-resize-mini-windows resize-mini-windows
+              resize-mini-windows 'grow-only)
         (advice-add 'icomplete-completions
                     :filter-return #'icomplete-vertical-format-completions)
         (add-hook 'icomplete-minibuffer-setup-hook

--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -48,6 +48,11 @@ It is then restored when icomplete-vertical-mode is turned off.")
 Records the value when `icomplete-vertical-mode' is turned on.
 It is then restored when icomplete-vertical-mode is turned off.")
 
+(defvar icomplete-vertical-old-prospects-height nil
+  "Store last known value of `icomplete-prospects-height'.
+Records the value when `icomplete-vertical-mode' is turned on.
+It is then restored when icomplete-vertical-mode is turned off.")
+
 (defun icomplete-vertical-format-completions (completions)
   "Reformat COMPLETIONS for better aesthetics.
 To be used as filter return advice for `icomplete-completions'."
@@ -77,14 +82,18 @@ Meant to be added to `icomplete-minibuffer-setup-hook'."
               icomplete-vertical-old-hide-common icomplete-hide-common-prefix
               icomplete-hide-common-prefix nil
               icomplete-vertical-old-resize-mini-windows resize-mini-windows
-              resize-mini-windows 'grow-only)
+              resize-mini-windows 'grow-only
+              icomplete-vertical-old-prospects-height icomplete-prospects-height
+              icomplete-prospects-height icomplete-vertical-prospects-height)
         (advice-add 'icomplete-completions
                     :filter-return #'icomplete-vertical-format-completions)
         (add-hook 'icomplete-minibuffer-setup-hook
                   #'icomplete-vertical-minibuffer-setup
                   5))
     (setq icomplete-separator icomplete-vertical-old-separator
-          icomplete-hide-common-prefix icomplete-vertical-old-hide-common)
+          icomplete-hide-common-prefix icomplete-vertical-old-hide-common
+          resize-mini-windows icomplete-vertical-old-resize-mini-windows
+          icomplete-prospects-height icomplete-vertical-old-prospects-height)
     (advice-remove 'icomplete-completions
                    #'icomplete-vertical-format-completions)
     (remove-hook 'icomplete-minibuffer-setup-hook


### PR DESCRIPTION
These patches seem to fix the issues #1 and #2 that I reported earlier.

As I note in https://github.com/oantolin/icomplete-vertical/commit/2e296853a131deefcede0f705392d2f9c6d24a89, I would still prefer a "cleaner" solution to the ability of the minibuffer to both expand and contract in size.  Whereas this will only allow it to grow.

With regard to https://github.com/oantolin/icomplete-vertical/commit/2d80c5f45e08eca9e4b5baf8cc4acefe41f3e40b, see screenshot below and compare it with those in #2:

![Screenshot at 2020-04-03 10-28-48](https://user-images.githubusercontent.com/12828033/78335611-9b57fb00-7596-11ea-8b4e-410e0cbfc805.png)
