### PR TITLE
Do not reduce (-1) height of candidates' list

### DIFF
--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -65,7 +65,7 @@ To be used as filter return advice for `icomplete-completions'."
 Meant to be added to `icomplete-minibuffer-setup-hook'."
   (visual-line-mode -1) ;just in case
   (setq truncate-lines t)
-  (enlarge-window (1- icomplete-vertical-prospects-height)))
+  (enlarge-window icomplete-vertical-prospects-height))
 
 ;;;###autoload
 (define-minor-mode icomplete-vertical-mode


### PR DESCRIPTION
This is to ensure that the number of candidates on display is always equal to `icomplete-vertical-prospects-height` (using `3` as an example).

## Before

![Screenshot at 2020-04-03 15-40-27](https://user-images.githubusercontent.com/12828033/78361954-e9cebf00-75c1-11ea-968c-81dc0d0564a7.png)

## After

![Screenshot at 2020-04-03 15-40-47](https://user-images.githubusercontent.com/12828033/78361924-dae80c80-75c1-11ea-83a3-10f13c6e237b.png)
