### PR TITLE
Expand commentary in `icomplete-vertical.el'

### DIFF
--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -20,10 +20,23 @@
 
 ;;; Commentary:
 
-;; This is a simple-minded global minor mode to comfortably use
-;; icomplete to display completion candidates vertically.  A simple
-;; (setq icomplete-separator "\n") gets you 95% of the way there, this
-;; small package just adds a few visual tweaks on top of that.
+;; This package defines a global minor mode to display Icomplete
+;; completion candidates vertically.  It solves certain problems that a
+;; mere (setq icomplete-separator "\n") could never overcome.
+;;
+;; Specifically, simply setting the separator to a newline presents two
+;; issues:
+;;
+;; 1 Usually the minibuffer prompt and the text you type scroll off to
+;;   the left!  This conceals the minibuffer prompt.
+;; 2 The first candidate appears on the same line as the one you are
+;;   typing in.  This clutters the view and can cause confusion.
+;;
+;; Both of these are addressed by enabling `icomplete-vertical-mode':
+;;
+;; + The minibuffer prompt remains visible.
+;; + The matching item appears on a line below the minibuffer input,
+;;   while being vertically aligned to the list of candidates.
 
 ;;; Code:
 (require 'icomplete)

--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -35,7 +35,7 @@
   :group 'icomplete)
 
 (defvar icomplete-vertical-saved-state nil
-  "Alist of certain variables and their last know value.
+  "Alist of certain variables and their last known value.
 Records the values when `icomplete-vertical-mode' is turned on.
 The values are restored when icomplete-vertical-mode is turned off.")
 


### PR DESCRIPTION
I think the "Commentary" should be informative.  This is useful when someone does `M-x find-library icomplete-vertical`.  In the future, it will also be the descritpion that people see when they open a help buffer with the package's details in `M-x list-packages`.

Feel free to reject this particular wording.