### PR TITLE
Expand gitignore to two standard file extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.elc
+*-autoloads.el
+*-pkg.el


### PR DESCRIPTION
I learnt about these from an ELPA maintainer.  Might be useful in other
packaging scenaria as well.

Again though, feel free to reject or adapt accordingly.