### PR TITLE
Enforce showing matches on no input

### DIFF
--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -172,6 +172,7 @@ minibuffer is in use."
          icomplete-vertical-saved-state
          (icomplete-separator icomplete-vertical-separator)
          (icomplete-hide-common-prefix nil)
+         (icomplete-show-matches-on-no-input t)
          (resize-mini-windows 'grow-only)
          (icomplete-prospects-height icomplete-vertical-prospects-height))
         (icomplete-vertical--apply-separator-face)


### PR DESCRIPTION
I was tweaking a few things earlier and noticed that without enforcing `icomplete-show-matches-on-no-input t`, the vertical layout may look broken.

Current `master` when `setq icomplete-show-matches-on-no-input nil`:

![Screenshot at 2020-04-08 21-49-48](https://user-images.githubusercontent.com/12828033/78822047-1714d600-79e3-11ea-8877-1e1b441e1929.png)

And this is with the patch:

![Screenshot at 2020-04-08 21-50-04](https://user-images.githubusercontent.com/12828033/78822084-22680180-79e3-11ea-85ef-430de9ab13e1.png)

Please confirm this finding.  Also check that I applied things correctly.