### PR TITLE
Silence linter on unknown `widget-convert' func

### DIFF
--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -57,6 +57,7 @@
 
 (require 'icomplete)
 (require 'cl-lib)
+(require 'wid-edit)
 
 (defgroup icomplete-vertical nil
   "Display icomplete candidates vertically."


### PR DESCRIPTION
This is the error I got once I activated `flymake-mode':

    the function ‘widget-convert’ is not known to be defined.

With this patch the linter is happy.  There seem to be no further complications.

Feel free to add, reject, adapt.