### PR TITLE
Fix compatibility with fido-mode

### DIFF
--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -227,7 +227,7 @@ minibuffer is in use."
          (icomplete-show-matches-on-no-input t)
          (resize-mini-windows 'grow-only)
          (icomplete-prospects-height icomplete-vertical-prospects-height))
-        (icomplete-mode)
+        (unless icomplete-mode (icomplete-mode)) ; Don't disable `fido-mode'.
         (icomplete-vertical--setup-separator)
         (advice-add 'icomplete-completions
                     :filter-return #'icomplete-vertical-format-completions)


### PR DESCRIPTION
When using fido-mode, a built-in layer on top of icomplete-mode, the
latter is already enabled. Unfortunately, explicitly enabling
icomplete-mode (like done here) disables fido-mode, and so breaks the
user's setup. We instead need to enable icomplete-mode if and only if it
is not enabled. To be honest, this behavior of Emacs seems problematic,
and I'll report it upstream, but this fixes it here.