### PR TITLE
Set only during customization

### DIFF
--- a/icomplete-vertical.el
+++ b/icomplete-vertical.el
@@ -131,6 +131,7 @@ the list, focus its text field, and enter its value with
           (string :tag "Custom string")
           (sexp :tag "Custom propertized string"))
   :group 'icomplete-vertical
+  :initialize 'custom-initialize-default
   :set (lambda (_ separator)
          (icomplete-vertical-set-separator separator)))
 


### PR DESCRIPTION
The custom `:set` function is currently called during `defcustom icomplete-vertical-separator` definition, which is undesirable as the dependency `(icomplete-vertical--setup-separator)`  of that function is yet to be defined during load time. On first load this will result in a `void-function` error. This PR fixes this issue.